### PR TITLE
Update to the api response naming convention

### DIFF
--- a/services/namah/routes/namah/api/v1/banners.js
+++ b/services/namah/routes/namah/api/v1/banners.js
@@ -4,6 +4,9 @@ const express = require('express');
 const getConnection = require('../../../../models/createPool');
 const getQuery = require('../../../../models/createQuery');
 
+//Services
+const {translateObjectListKeys} = require('../../../../services');
+
 const router = express.Router();
 
 router.get('/', (req, res) => {
@@ -23,7 +26,7 @@ router.get('/', (req, res) => {
                 }else{
                     res.status(200).json({
                         success: true,
-                        banners: result
+                        banners: translateObjectListKeys(result)
                     });
                 }
             })

--- a/services/namah/routes/namah/api/v1/concetps.js
+++ b/services/namah/routes/namah/api/v1/concetps.js
@@ -4,6 +4,9 @@ const express = require('express');
 const getConnection = require('../../../../models/createPool');
 const getQuery = require('../../../../models/createQuery');
 
+//Services
+const {translateObjectListKeys} = require('../../../../services');
+
 const router = express.Router();
 
 router.get('/', (req, res) => {
@@ -22,7 +25,7 @@ router.get('/', (req, res) => {
                 }else{
                     res.status(200).json({
                         success: true,
-                        concepts: result
+                        concepts: translateObjectListKeys(result)
                     });
                 }
             })

--- a/services/namah/routes/namah/api/v1/courses.js
+++ b/services/namah/routes/namah/api/v1/courses.js
@@ -11,15 +11,15 @@ const generateCourseList = (course) => {
 
     course.forEach((element,index) => {
         coursesList[index] = { 
-            course_id: element.course_id,
-            course_author: element.course_author,
-            course_title: element.course_title,
-            course_description: element.course_description,
-            course_date: {
-                course_start_date: element.course_start_date,
-                course_end_date: element.course_end_date
+            courseId: element.course_id,
+            courseAuthor: element.course_author,
+            courseTitle: element.course_title,
+            courseDescription: element.course_description,
+            courseDate: {
+                courseStartDate: element.course_start_date,
+                courseEndDate: element.course_end_date
             }
-        }
+        };
     });
 
     return coursesList;
@@ -39,11 +39,9 @@ router.get('/', (req, res) => {
                         description: 'No courses found'
                     });
                 }else{
-                    const coursesList = generateCourseList(result);
-    
                     res.status(200).json({
                         success: true,
-                        courses: coursesList
+                        courses: generateCourseList(result)
                     });
                 }
             })

--- a/services/namah/routes/namah/api/v1/podcasts.js
+++ b/services/namah/routes/namah/api/v1/podcasts.js
@@ -4,6 +4,9 @@ const express = require('express');
 const getConnection = require('../../../../models/createPool');
 const getQuery = require('../../../../models/createQuery');
 
+//Services
+const {translateObjectListKeys} = require('../../../../services');
+
 const router = express.Router();
 
 router.get('/', (req, res) => {
@@ -22,7 +25,7 @@ router.get('/', (req, res) => {
                 }else{
                     res.status(200).json({
                         success: true,
-                        podcasts: result
+                        podcasts: translateObjectListKeys(result)
                     });
                 }
             })

--- a/services/namah/routes/namah/api/v1/posts.js
+++ b/services/namah/routes/namah/api/v1/posts.js
@@ -4,6 +4,9 @@ const express = require('express');
 const getConnection = require('../../../../models/createPool');
 const getQuery = require('../../../../models/createQuery');
 
+//Services
+const {translateObjectListKeys} = require('../../../../services');
+
 const router = express.Router();
 
 router.get('/', (req, res) => {
@@ -22,7 +25,7 @@ router.get('/', (req, res) => {
                 }else{
                     res.status(200).json({
                         success: true,
-                        posts: result
+                        posts: translateObjectListKeys(result)
                     });
                 }
             })

--- a/services/namah/routes/namah/api/v1/products.js
+++ b/services/namah/routes/namah/api/v1/products.js
@@ -4,6 +4,9 @@ const express = require('express');
 const getConnection = require('../../../../models/createPool');
 const getQuery = require('../../../../models/createQuery');
 
+//Services
+const {translateObjectListKeys} = require('../../../../services');
+
 const router = express.Router();
 
 router.get('/', (req, res) => { 
@@ -22,7 +25,7 @@ router.get('/', (req, res) => {
                 }else{
                     res.status(200).json({
                         success: true,
-                        products: result
+                        products: translateObjectListKeys(result)
                     });
                 }
             })

--- a/services/namah/routes/namah/api/v1/users.js
+++ b/services/namah/routes/namah/api/v1/users.js
@@ -4,6 +4,9 @@ const express = require('express');
 const getConnection = require('../../../../models/createPool');
 const getQuery = require('../../../../models/createQuery');
 
+//Services
+const {translateObjectListKeys} = require('../../../../services');
+
 const router = express.Router();
 
 router.get('/', (req, res) => {
@@ -26,7 +29,7 @@ router.get('/', (req, res) => {
                 }else{
                     res.status(200).json({
                         success: true,
-                        users: result
+                        users: translateObjectListKeys(result)
                     });
                 }
             })

--- a/services/namah/services/index.js
+++ b/services/namah/services/index.js
@@ -44,7 +44,7 @@ const generateQuery = ({requestQueries, targetItems, targetTable, targetIsBinary
         const firstIndex = Object.keys(requestQueries).indexOf(Object.keys(requestQueries).find(element => element !== 'limit' && requestQueries[element] !== undefined));
 
         Object.keys(requestQueries).map((element, index) => {
-            if(element === 'search_query'){             
+            if(element === 'q'){             
                 for(const [targetItemKey, targetItemValue] of Object.entries(targetItems)){
                     if(targetItemKey === '0'){
                         queryClauses = queryClauses + ` WHERE ${targetItemValue} LIKE CONCAT('%', ?, '%')`;
@@ -84,3 +84,53 @@ const generateQuery = ({requestQueries, targetItems, targetTable, targetIsBinary
 };
 
 exports.generateQuery = generateQuery;
+
+const toCamelCase = (str) => {
+    const map = {
+        'a' : 'á|à|ã|â|À|Á|Ã|Â',
+        'e' : 'é|è|ê|É|È|Ê',
+        'i' : 'í|ì|î|Í|Ì|Î',
+        'o' : 'ó|ò|ô|õ|Ó|Ò|Ô|Õ',
+        'u' : 'ú|ù|û|ü|Ú|Ù|Û|Ü',
+        'c' : 'ç|Ç',
+        'n' : 'ñ|Ñ'
+    };
+    
+    for(let pattern in map){
+        str = str.replace(new RegExp(map[pattern], 'g'), pattern);
+    };
+
+    return str.replace(/([-_][a-z]|[A-Z]|)/g, (word, index) => {
+        return index === 0 ? word.toLowerCase() : word.toUpperCase();
+    }).replace(/[^a-zA-Z]/g, '',/\s/g, '',/[0-9]/g,'');
+};
+
+exports.toCamelCase = toCamelCase;
+
+const translateObjectKeys = (targetObject) => {
+    let newObject = {};
+    
+    for(const [key, value] of Object.entries(targetObject)){
+        if(value && typeof value === 'object' && typeof value.getMonth !== 'function'){
+            newObject = {...newObject, [toCamelCase(key)]: translateObjectKeys(value)};
+        }else{
+            newObject = {...newObject, [toCamelCase(key)]: value}; 
+        };
+    };
+
+    return newObject;
+};
+
+exports.translateObjectKeys = translateObjectKeys;
+
+const translateObjectListKeys = (targetObjectList) => {
+    const newObjectList = new Array(targetObjectList.length);
+
+    targetObjectList.forEach((currentObject, index) => {
+        newObjectList[index] = translateObjectKeys(currentObject);
+    });
+
+    return newObjectList;
+};
+
+exports.translateObjectListKeys = translateObjectListKeys;


### PR DESCRIPTION
## Info

This is one step towards ```api response``` overhaul, which consists in changing from ```snake_case``` to ```camelCase```.

## Problems  

1. Missing ```camelCase``` converter;

2. Change the ```api response``` naming convention to ```camelCase```.

## Fix

1. Introduced ```camelCase``` converter service & updated the ```search``` endpoint query parameter name at fa9c7ee;

2. Implemented the ```camelCase``` converter:

    2.1. Introduced to the ```banners``` endpoint at 4870fe1;

    2.2. Introduced to the ```concepts``` endpoint at b26172d;

    2.3. Introduced to the ```courses``` endpoint at 79a0507;

    2.4. Introduced to the ```podcasts``` endpoint at bbd633c;

    2.5. Introduced to the ```posts``` endpoint at 5847857;

    2.6. Introduced to the ```products``` endpoint at c059d63;

    2.7. Introduced to the ```search``` endpoint at afdc4a3;

    2.8. Introduced to the ```users``` endpoint at eb1e47f;