### PR TITLE
Fixed searchResult keys order iconsistency

### DIFF
--- a/services/namah/routes/namah/api/v1/search.js
+++ b/services/namah/routes/namah/api/v1/search.js
@@ -7,7 +7,8 @@ const getQuery = require('../../../../models/createQuery');
 //Services
 const {
     toCamelCase,
-    translateObjectListKeys
+    translateObjectListKeys,
+    orderObjectByKey
 } = require('../../../../services');
 
 const router = express.Router();
@@ -66,7 +67,7 @@ router.get('/', async (req, res) => {
                             if(Object.keys(searchResult).length === avaiableTables.length){
                                 res.status(200).json({
                                     success: true,
-                                    searchResult: searchResult
+                                    searchResult: orderObjectByKey(searchResult)
                                 });
                             }
                         })

--- a/services/namah/services/index.js
+++ b/services/namah/services/index.js
@@ -4,3 +4,4 @@ exports.generateQuery = require('./generateQuery');
 exports.toCamelCase = require('./toCamelCase');
 exports.translateObjectKeys = require('./translateObjectKeys');
 exports.translateObjectListKeys = require('./translateObjectListKeys');
+exports.orderObjectByKey = require('./orderObjectByKey');

--- a/services/namah/services/orderObjectByKey.js
+++ b/services/namah/services/orderObjectByKey.js
@@ -1,0 +1,11 @@
+const orderObjectByKey = (unorderedObject) => {
+    return Object.keys(unorderedObject).sort().reduce(
+        (obj, key) => { 
+          obj[key] = unorderedObject[key]; 
+          return obj;
+        }, 
+        {}
+    );
+};
+
+module.exports = orderObjectByKey;


### PR DESCRIPTION
## Info

As of it right now the ```searchResult``` shows some inconsistencies when it comes to the keys order.

## Problems  

1. Missing a object ordering service;

2. The ```searchResult``` shows keys order inconsistencies.

## Fix

- [x] 1. Introduced object ordering service at 0bc6703;

- [x] 2. Implemented  the object ordering service in the ```search``` endpoint at a9bef22.